### PR TITLE
Reimplement network_id and fix it up for proper usage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(Vulpes SHARED
     halo/memory/types.cpp
 
     halo/network/foxnet/vulpes_message.cpp
+    halo/network/network_id.cpp
 
     halo/tweaks/loading_screen.cpp
     halo/tweaks/tweaks.cpp

--- a/command/debug.cpp
+++ b/command/debug.cpp
@@ -9,6 +9,7 @@
 #include "../halo/functions/messaging.hpp"
 #include "../halo/fixes/shdr_trans_zfighting.hpp"
 #include "../halo/memory/gamestate/network.hpp"
+#include "../halo/network/network_id.hpp"
 
 bool toggle_shader_trans_fix(std::vector<VulpesArg> input){
     bool on = input[0].bool_out();
@@ -41,6 +42,18 @@ bool toggle_allow_client_side_projectiles(std::vector<VulpesArg> input){
     return true;
 }
 
+bool get_network_id_from_obj_id(std::vector<VulpesArg> input){
+    uint32_t id = input[0].int_out();
+    cprintf("%d", get_network_id_from_object(*reinterpret_cast<MemRef*>(&id)));
+    return true;
+}
+
+bool get_object_id_from_network_id(std::vector<VulpesArg> input){
+    uint32_t id = input[0].int_out();
+    cprintf("0x%X", get_object_from_network_index(id));
+    return true;
+}
+
 void init_debug_commands(){
     static VulpesCommand cmd_dev_shader_transparent_fix(
         "v_dev_shader_transparent_fix",
@@ -51,5 +64,16 @@ void init_debug_commands(){
         "v_dev_allow_client_side_projectiles",
         &toggle_allow_client_side_projectiles, 4, 1,
         VulpesArgDef("", false, A_BOOL)
+    );
+
+    static VulpesCommand cmd_get_network_id_from_obj_id(
+        "v_dev_get_network_id_from_obj_id",
+        &get_network_id_from_obj_id, 0, 1,
+        VulpesArgDef("", true, A_LONG)
+    );
+    static VulpesCommand cmd_get_object_id_from_network_id(
+        "v_dev_get_object_id_from_network_id",
+        &get_object_id_from_network_id, 0, 1,
+        VulpesArgDef("", true, A_LONG)
     );
 }

--- a/command/debug.cpp
+++ b/command/debug.cpp
@@ -68,12 +68,12 @@ void init_debug_commands(){
 
     static VulpesCommand cmd_get_network_id_from_obj_id(
         "v_dev_get_network_id_from_obj_id",
-        &get_network_id_from_obj_id, 0, 1,
+        &get_network_id_from_obj_id, 4, 1,
         VulpesArgDef("", true, A_LONG)
     );
     static VulpesCommand cmd_get_object_id_from_network_id(
         "v_dev_get_object_id_from_network_id",
-        &get_object_id_from_network_id, 0, 1,
+        &get_object_id_from_network_id, 4, 1,
         VulpesArgDef("", true, A_LONG)
     );
 }

--- a/halo/network/network_id.cpp
+++ b/halo/network/network_id.cpp
@@ -7,8 +7,6 @@
 #include "../../hooker/hooker.hpp"
 #include "../memory/types.hpp"
 
-Signature(true, sig_message_delta_object_index, {0x8B, 0x44, 0x24, 0x14, 0x50, 0x8B, 0xCF, 0xB8, -1, -1, -1, -1, 0xE8});
-
 Signature(true, sig_func_server_register_network_index, {0x55, 0x56, 0x8B, 0x70, 0x58, 0x8A, 0x46, 0x0C, 0x8D, 0x6E, 0x0C, 0x57, 0x83, 0xCF, 0xFF, 0x3C, 0x01, 0x75});
 
 Signature(true, sig_func_client_register_network_index_from_remote, {0x8B, 0x40, 0x58, 0x8B, 0x50, 0x28, 0x53, 0x55, 0x8B, 0x6C, 0x24, 0x0C, 0x57, 0x8D, 0x3C, 0xAA, 0x8B, 0x17, 0x32, 0xDB, 0x83, 0xFA, 0xFF, 0x75});
@@ -38,6 +36,8 @@ struct SyncedObjectHeader{
     MemRef* translation_index;      //0x28 // same as network_translation_table
 };
 
+// Pointer to a pointer because the game might change the actual pointer
+// So we want to read what is in the game's pointer to make sure we're safe.
 SyncedObjectHeader** synced_objects_header = NULL;
 
 int32_t server_register_network_index(MemRef object){
@@ -48,13 +48,13 @@ int32_t server_register_network_index(MemRef object){
     };
     int32_t network_id;
     asm (
-        "mov eax, %[message_delta_object_index];"
+        "mov eax, %[synced_objects];"
         "push %[local_object_id];"
         "call %[server_register_network_index];"
         "mov %[network_id], eax;"
         "add esp, 4;"
         :
-        : [message_delta_object_index] "m" (message_delta_object_index),
+        : [synced_objects] "m" (synced_objects),
           [network_id] "m" (network_id),
           [local_object_id] "m" (object.raw),
           [server_register_network_index] "m" (func_server_register_network_index)
@@ -63,14 +63,15 @@ int32_t server_register_network_index(MemRef object){
 }
 
 void register_network_index_from_remote(int32_t network_id, MemRef object){
+    SyncedObjectHeader* synced_objects = *synced_objects_header;
     asm (
-        "mov eax, %[message_delta_object_index];"
+        "mov eax, %[synced_objects];"
         "mov ecx, %[local_object_id];"
         "push %[network_id];"
         "call %[client_register_network_index_from_remote];"
         "add esp, 4;"
         :
-        : [message_delta_object_index] "m" (message_delta_object_index),
+        : [synced_objects] "m" (synced_objects),
           [local_object_id] "m" (object.raw),
           [network_id] "m" (network_id),
           [client_register_network_index_from_remote] "m" (func_client_register_network_index_from_remote)
@@ -78,12 +79,26 @@ void register_network_index_from_remote(int32_t network_id, MemRef object){
 }
 
 void unregister_network_index(MemRef object){
+    /*
+     * We're creating this struct here because the original code looks for
+     * synced_objects at the offset 0x58 from the pointer in eax.
+     *
+     * What it does:
+     * mov edi, [eax+58h]
+     *
+     * This is just easier and more reliable than writing an ASM workaround.
+     */
+    struct {
+        PAD(0x58);
+        SyncedObjectHeader* synced_objects = *synced_objects_header;
+    }synced_objects;
+    auto synced_objects_ptr = &synced_objects;
     asm (
-        "mov eax, %[message_delta_object_index];"
+        "mov eax, %[synced_objects_ptr];"
         "mov esi, %[local_object_id];"
         "call %[unregister_network_index];"
         :
-        : [message_delta_object_index] "m" (message_delta_object_index),
+        : [synced_objects_ptr] "m" (synced_objects_ptr),
           [local_object_id] "m" (object.raw),
           [unregister_network_index] "m" (func_unregister_network_index)
     );
@@ -106,8 +121,10 @@ int32_t get_network_id_from_object(MemRef object){
 
 void init_network_id(){
     synced_objects_header = reinterpret_cast<SyncedObjectHeader**>(*reinterpret_cast<uintptr_t**>(sig_translation_table_ptr.address()));
-    message_delta_object_index = *reinterpret_cast<uintptr_t*>(sig_message_delta_object_index.address() + 8);
-    func_server_register_network_index = sig_func_server_register_network_index.address();
-    func_client_register_network_index_from_remote = sig_func_client_register_network_index_from_remote.address();
+    // +3 because if we enter the function on the second instruction
+    // we only need to supply the pointer to the synced_object_header.
+    func_server_register_network_index = sig_func_server_register_network_index.address() + 3;
+    func_client_register_network_index_from_remote = sig_func_client_register_network_index_from_remote.address() + 3;
+    // Not here because the function is a little more complicated.
     func_unregister_network_index = sig_func_unregister_network_index.address();
 }

--- a/halo/network/network_id.cpp
+++ b/halo/network/network_id.cpp
@@ -7,8 +7,6 @@
 #include "../../hooker/hooker.hpp"
 #include "../memory/types.hpp"
 
-Signature(true, sig_message_delta_object_index, {0x8B, 0x44, 0x24, 0x14, 0x50, 0x8B, 0xCF, 0xB8, -1, -1, -1, -1, 0xE8});
-
 Signature(true, sig_func_server_register_network_index, {0x55, 0x56, 0x8B, 0x70, 0x58, 0x8A, 0x46, 0x0C, 0x8D, 0x6E, 0x0C, 0x57, 0x83, 0xCF, 0xFF, 0x3C, 0x01, 0x75});
 
 Signature(true, sig_func_client_register_network_index_from_remote, {0x8B, 0x40, 0x58, 0x8B, 0x50, 0x28, 0x53, 0x55, 0x8B, 0x6C, 0x24, 0x0C, 0x57, 0x8D, 0x3C, 0xAA, 0x8B, 0x17, 0x32, 0xDB, 0x83, 0xFA, 0xFF, 0x75});
@@ -17,7 +15,6 @@ Signature(true, sig_func_unregister_network_index, {0x53, 0x57, 0x8B, 0x78, 0x58
 
 Signature(true, sig_translation_table_ptr, {-1, -1, -1, -1, 0x8B, 0x52, 0x28, 0x8B, 0x34, 0x8A});
 
-uintptr_t message_delta_object_index = *reinterpret_cast<uintptr_t*>(sig_message_delta_object_index.address() + 8);
 uintptr_t func_server_register_network_index = sig_func_server_register_network_index.address();
 uintptr_t func_client_register_network_index_from_remote = sig_func_client_register_network_index_from_remote.address();
 uintptr_t func_unregister_network_index = sig_func_unregister_network_index.address();
@@ -38,7 +35,7 @@ struct SyncedObjectHeader{
 };
 
 int32_t server_register_network_index(MemRef object){
-    SyncedObjectHeader* synced_objects = reinterpret_cast<SyncedObjectHeader*>(message_delta_object_index + 0x58);
+    SyncedObjectHeader* synced_objects = reinterpret_cast<SyncedObjectHeader*>(**reinterpret_cast<uintptr_t**>(sig_translation_table_ptr.address()));
     if (synced_objects->count >= synced_objects->max_count){
         // Just don't even try if we're at max capacity.
         return -1;
@@ -85,15 +82,14 @@ void unregister_network_index(MemRef object){
 }
 
 MemRef get_object_from_network_index(int32_t network_id){
-    static MemRef* network_translation_table = reinterpret_cast<MemRef*>(*reinterpret_cast<uintptr_t*>(sig_translation_table_ptr.address()) + 0x28);
-    return network_translation_table[network_id];
+    SyncedObjectHeader* synced_objects = reinterpret_cast<SyncedObjectHeader*>(**reinterpret_cast<uintptr_t**>(sig_translation_table_ptr.address()));
+    return synced_objects->translation_index[network_id];
 }
 
 int32_t get_network_id_from_object(MemRef object){
-    SyncedObjectHeader* synced_objects = reinterpret_cast<SyncedObjectHeader*>(message_delta_object_index + 0x58);
-    static MemRef* network_translation_table = reinterpret_cast<MemRef*>(*reinterpret_cast<uintptr_t*>(sig_translation_table_ptr.address()) + 0x28);
+    SyncedObjectHeader* synced_objects = reinterpret_cast<SyncedObjectHeader*>(**reinterpret_cast<uintptr_t**>(sig_translation_table_ptr.address()));
     for (int i=1; i < synced_objects->max_count; i++){
-        if (network_translation_table[i].raw == object.raw){
+        if (synced_objects->translation_index[i].raw == object.raw){
             return i;
         };
     };

--- a/halo/network/network_id.cpp
+++ b/halo/network/network_id.cpp
@@ -41,7 +41,7 @@ struct SyncedObjectHeader{
 SyncedObjectHeader** synced_objects_header = NULL;
 
 int32_t server_register_network_index(MemRef object){
-    SyncedObjectHeader* synced_objects = reinterpret_cast<SyncedObjectHeader*>(**reinterpret_cast<uintptr_t**>(sig_translation_table_ptr.address()));
+    SyncedObjectHeader* synced_objects = *synced_objects_header;
     if (synced_objects->count >= synced_objects->max_count){
         // Just don't even try if we're at max capacity.
         return -1;
@@ -52,6 +52,7 @@ int32_t server_register_network_index(MemRef object){
         "push %[local_object_id];"
         "call %[server_register_network_index];"
         "mov %[network_id], eax;"
+        "add esp, 4;"
         :
         : [message_delta_object_index] "m" (message_delta_object_index),
           [network_id] "m" (network_id),
@@ -67,6 +68,7 @@ void register_network_index_from_remote(int32_t network_id, MemRef object){
         "mov ecx, %[local_object_id];"
         "push %[network_id];"
         "call %[client_register_network_index_from_remote];"
+        "add esp, 4;"
         :
         : [message_delta_object_index] "m" (message_delta_object_index),
           [local_object_id] "m" (object.raw),

--- a/halo/network/network_id.hpp
+++ b/halo/network/network_id.hpp
@@ -24,8 +24,14 @@ void    register_network_index_from_remote(int32_t network_id, MemRef object);
 // Used when an object should not be synced anymore.
 void    unregister_network_index(MemRef object);
 
+//            ||||
+// These work VVVV
+
 // Used for translating remote ids in messages.
 MemRef  get_object_from_network_index(int32_t network_id);
 
 // Used to find the network id for an object, when creating packets to send over.
 int32_t get_network_id_from_object(MemRef object); // returns -1 if not found.
+
+// Initialize all the pointers.
+void init_network_id();

--- a/halo/network/network_id.hpp
+++ b/halo/network/network_id.hpp
@@ -12,8 +12,6 @@
 ////// There is only 511 network id slots, and when figuring this all out
 ////// I have seen a few servers that saturate these slots pretty badly.
 
-////// Everything in here is currently untested. This may very well not work.
-
 
 // Used to register a new id on creation of an object that we want to sync.
 int32_t server_register_network_index(MemRef object); // Returns -1 if there is no space to add one.
@@ -23,9 +21,6 @@ void    register_network_index_from_remote(int32_t network_id, MemRef object);
 
 // Used when an object should not be synced anymore.
 void    unregister_network_index(MemRef object);
-
-//            ||||
-// These work VVVV
 
 // Used for translating remote ids in messages.
 MemRef  get_object_from_network_index(int32_t network_id);

--- a/vulpes.cpp
+++ b/vulpes.cpp
@@ -93,8 +93,9 @@ void init_halo_functions(){
     init_message_delta_sender();
 }
 
-
+#include "halo/network/network_id.hpp"
 void init_network(){
+    init_network_id();
 }
 
 #include "halo/functions/messaging.hpp"


### PR DESCRIPTION
This file is old. I had to do a bit of work to get it up to standard, but here it is.

Each function's purpose is described in the header.

These functions handle the retrieving, creating, deleting of network ids used by Halo to see what object equates to what other object between a client and a server.

There also is some debug commands I used for testing these that I see no harm in keeping in the project.