### PR TITLE
Don't generate C++ files from yaml files that haven't changed since last time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ lib/LuaJIT/
 
 # Ignore auto generated code
 generated/
+
+# Ignore cache that has hashes of all the generated files.
+*.tmp

--- a/codegen/generate.pl
+++ b/codegen/generate.pl
@@ -10,7 +10,7 @@ use warnings;
 
 # If you see a pull request that changes this system and it does not
 # have a change for this constant you should ready the firing squad.
-use constant VERSION => "1.1.0";
+our $VERSION = '1.1.0';
 
 use Digest::SHA1 qw( sha1_base64 );
 use File::Basename qw( dirname basename );
@@ -38,7 +38,7 @@ qq{/*
 use constant GEN_INFO_FILE => "./codegen_hashes.tmp";
 # Compile info
 my %info = (
-    version => VERSION,
+    version => $VERSION,
 );
 # Load info from previous compilation if it exists
 if (-e GEN_INFO_FILE) {

--- a/codegen/generate.pl
+++ b/codegen/generate.pl
@@ -7,10 +7,17 @@
 
 use strict;
 use warnings;
+
+# If you see a pull request that changes this system and it does not
+# have a change for this constant you should ready the firing squad.
+use constant VERSION => "1.1.0";
+
+use Digest::SHA1  qw( sha1_base64 );
 use File::Basename qw( dirname basename );
+use File::Slurper qw( read_text );
 use File::Spec::Functions qw( catfile );
 use File::Path qw( make_path );
-use YAML::XS qw( LoadFile );
+use YAML::XS qw( LoadFile Load Dump );
 
 use lib dirname(__FILE__); # Include own directory
 use CodeGen::Signature qw( yaml_signatures_to_cpp_definitions );
@@ -28,6 +35,32 @@ qq{/*
 };
 }
 
+use constant GEN_INFO_FILE => "./codegen_hashes.tmp";
+# Compile info
+my %info = (
+    version => VERSION,
+);
+# Load info from previous compilation if it exists
+if (-e GEN_INFO_FILE) {
+    print "[prep] Loading data from previous compilation...";
+    # eval to catch it if the GEN_INFO_FILE is corrupt.
+    # Insane edge case as no one should ever edit it.
+    # But, better safe than sorry.
+    eval {
+        my $old_info = LoadFile GEN_INFO_FILE;
+        if ($old_info->{version} eq $info{version}) {
+            print "usable!\n";
+            # There is a potential for carrying over arbitrary data here.
+            # But not in any dangerous way because of the use case.
+            $info{hashes} = $old_info->{hashes};
+        } else {
+            print "not usable.\n";
+        } 1;
+    } or do {
+        print "fail.\n"
+    }
+}
+
 my $input_file_count = scalar @ARGV;
 my $i = 0;
 
@@ -35,10 +68,7 @@ foreach my $filename (@ARGV) {
     # Terminal output non-sense.
     $i++;
     my $progress = int(($i*100)/$input_file_count);
-    printf "[%3d%s] Building CPP files for %s\n", $progress, "%", $filename;
-
-    # Load yaml definition.
-    my $file = LoadFile $filename;
+    printf "[%3d%%] Building CPP files for %s...", $progress, $filename;
 
     # Get path without file extension.
     my $output_stem = $filename;
@@ -51,9 +81,30 @@ foreach my $filename (@ARGV) {
     my $dir = catfile catfile (dirname $output_stem), "generated";
     make_path $dir;
 
+    # get names of our output files.
+    my $output_src  = catfile $dir, "$name.cpp";
+    my $output_head = catfile $dir, "$name.hpp";
+
+    # Load yaml definition as text
+    my $file = read_text $filename;
+
+    # Check if file is the same as the last time
+    my $sha = sha1_base64 $file;
+    my $old_sha = $info{hashes}{$filename} // "";
+    if ($sha eq $old_sha and -e $output_src and -e $output_head) {
+        # Skip if the same and both output files exist.
+        print "skipped.\n";
+        next;
+    }
+    # Overwrite old hash.
+    $info{hashes}{$filename} = $sha;
+
+    # Actually load the yaml
+    $file = Load $file;
+
     # Open new source and headers for writing.
-    open(OUTPUT_SRC,  ">".(catfile $dir, "$name.cpp"));
-    open(OUTPUT_HEAD, ">".(catfile $dir, "$name.hpp"));
+    open(OUTPUT_SRC,  ">$output_src");
+    open(OUTPUT_HEAD, ">$output_head");
 
     # basename with yaml extension
     my $yaml_basename = basename($filename);
@@ -80,4 +131,14 @@ foreach my $filename (@ARGV) {
 
     close(OUTPUT_SRC);
     close(OUTPUT_HEAD);
+
+    print "done.\n";
 };
+
+# Save info from this compile to make future compiles quicker. If the
+# script fails anywhere before this this info can obviously not be saved.
+# That's intentional.
+print "[100%] Saving compile info.\n";
+open(COMPILE_INFO, ">".GEN_INFO_FILE);
+print COMPILE_INFO Dump \%info;
+close(COMPILE_INFO);

--- a/codegen/generate.pl
+++ b/codegen/generate.pl
@@ -35,7 +35,7 @@ qq{/*
 };
 }
 
-use constant GEN_INFO_FILE => "./codegen_hashes.tmp";
+use constant GEN_INFO_FILE => "./.codegen_hashes.tmp";
 # Compile info
 my %info = (
     version => $VERSION,
@@ -56,9 +56,7 @@ if (-e GEN_INFO_FILE) {
         } else {
             print "not usable.\n";
         } 1;
-    } or do {
-        print "fail.\n"
-    }
+    } or print "fail.\n";
 }
 
 my $input_file_count = scalar @ARGV;

--- a/codegen/generate.pl
+++ b/codegen/generate.pl
@@ -12,7 +12,7 @@ use warnings;
 # have a change for this constant you should ready the firing squad.
 use constant VERSION => "1.1.0";
 
-use Digest::SHA1  qw( sha1_base64 );
+use Digest::SHA1 qw( sha1_base64 );
 use File::Basename qw( dirname basename );
 use File::Slurper qw( read_text );
 use File::Spec::Functions qw( catfile );


### PR DESCRIPTION
Using a sha-1 to check if the yaml file is different. If it is then we regenerate.
Always regenerate when one of the compiled files is missing.

This is needed so that the Cmake generated makefile doesn't recompile the whole project every time.